### PR TITLE
Fix erratic behavior in opera

### DIFF
--- a/Hayoo/index/hayoo/hayoo.js
+++ b/Hayoo/index/hayoo/hayoo.js
@@ -98,7 +98,6 @@ function displayResult (result, query) {
   if (refreshRequired) {
     refreshRequired = false;
     $("result").replace(result);
-    $("querytext").defaultValue = query;
   }
   $("throbber").hide();
 }


### PR DESCRIPTION
Removed update of the query text input on query success. Why was this there in the first place? This overwrote any changes to the query input done while a query is running.
